### PR TITLE
Remove unnecessary double quote escape in config value

### DIFF
--- a/build-tools/helpers.js
+++ b/build-tools/helpers.js
@@ -147,8 +147,6 @@ const getMacrosFromMbedAppJson = async function(filename) {
 
         let value = mbedapp_conf[key].value.toString();
 
-        value = value.replace(/"/g, '\\"');
-
         macros.push(macroKey + '=' + value);
     }
 
@@ -166,8 +164,6 @@ const getMacrosFromMbedAppJson = async function(filename) {
         else {
             key = 'MBED_CONF_APP_' + key.toUpperCase().replace(/(-|\.)/g, '_');
         }
-
-        value = value.replace(/"/g, '\\"');
 
         let alreadyInMacros = macros.filter(m => {
             return m === key || m.indexOf(key + '=') === 0;


### PR DESCRIPTION
As the [documentation](https://os.mbed.com/docs/v5.8/reference/configuration.html) shows, users have to explicitly escape double quotes in string config value e.g., `"value": "\"Hello!\""`.

Thus, the config parser doesn't need to escape the character; current parser implementation `value = value.replace(/"/g, '\\"');` causes an error against the appropriately escaped config value as:

```
<command line>:17:38: note: expanded from here
#define MBED_CONF_APP_WELCOME_STRING \Hello!\\
```

We can delete the parser-side escape code.