### PR TITLE
Support `macro_name` and `required` key in mbed_app.json config

### DIFF
--- a/build-tools/helpers.js
+++ b/build-tools/helpers.js
@@ -138,7 +138,7 @@ const getMacrosFromMbedAppJson = async function(filename) {
 
     let mbedapp_conf = mbedapp.config || {};
     for (let key of Object.keys(mbedapp_conf)) {
-        let macroKey = 'MBED_CONF_APP_' + key.toUpperCase().replace(/(-|\.)/g, '_');
+        let macroKey = mbedapp_conf[key].macro_name || 'MBED_CONF_APP_' + key.toUpperCase().replace(/(-|\.)/g, '_');
 
         if (!mbedapp_conf[key].value) {
             macros.push(macroKey);

--- a/build-tools/helpers.js
+++ b/build-tools/helpers.js
@@ -141,6 +141,9 @@ const getMacrosFromMbedAppJson = async function(filename) {
         let macroKey = mbedapp_conf[key].macro_name || 'MBED_CONF_APP_' + key.toUpperCase().replace(/(-|\.)/g, '_');
 
         if (!mbedapp_conf[key].value) {
+            if (mbedapp_conf[key].required) {
+                throw "Required parameter '" + key + "' doesn't have a value";
+            }
             macros.push(macroKey);
             continue;
         }


### PR DESCRIPTION
Current config parser doesn't recognize these keys specified in `mbed_app.json` config file.

This PR supports these two options as the [documentation describes](https://os.mbed.com/docs/v5.8/reference/configuration.html) and [original Mbed OS config parser does](https://github.com/ARMmbed/mbed-os/blob/master/tools/config/__init__.py#L93).