### PR TITLE
Build tools no longer pick up components since #33

### DIFF
--- a/build-tools/build-libmbed.js
+++ b/build-tools/build-libmbed.js
@@ -33,8 +33,8 @@ let libmbed = {
         // 2. loop over the array, if no header files and no other folders mention the specific substring then filter out
         let dirsToRemove = []; // don't mess with the array when iterating
         for (let d of dirs) {
-            // check if .h or .hpp file in the current folder
-            let hasHeaderFiles = (await promisify(fs.readdir)(d)).some(f => ['.h', '.hpp'].indexOf(Path.extname(f)) > -1);
+            // check if .h or .hpp file in the current folder, *ALSO* check for .js files, as these could be components
+            let hasHeaderFiles = (await promisify(fs.readdir)(d)).some(f => ['.h', '.hpp', '.js'].indexOf(Path.extname(f)) > -1);
             // should not be the same, should not be in removal array, and should match substr
             let hasChildren = dirs.filter(sd => sd !== d && sd.indexOf(d) > -1 && dirsToRemove.indexOf(sd) === -1).length > 0;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-simulator",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Mbed OS 5 simulator",
   "preferGlobal": true,
   "scripts": {


### PR DESCRIPTION
This is a hotfix for #34. An issue arised where components are no longer loaded since #33 landed. This is because the list of included directories now only contains folders that contain `.h` or `.hpp` files, which excludes the components folders (which contain `.js`). I assumed the list only was used to invoke emcc but it's not. Adding `.js` to list of valid extensions restores behavior.