### PR TITLE
Allow downlink messages scheduled later than 5s

### DIFF
--- a/server/launch-server.js
+++ b/server/launch-server.js
@@ -456,7 +456,7 @@ module.exports = function(outFolder, port, staticMaxAge, runtimeLogs, callback) 
                 let now = Date.now() - startupTs;
                 let tts = (data.txpk.tmst / 1000) - now;
                 consoleLog('time to send is', tts);
-                if (tts < 0 || tts > 5000) {
+                if (tts < 0) {
                     consoleLog('tts invalid');
                     delay = 0;
                 }


### PR DESCRIPTION
Join accept is 5 seconds, but the RX1 delay can be up to 15 seconds for other downlink. I removed the check as you may want to schedule even further in the future in case of class B or C downlink.